### PR TITLE
SagePay Server - Prevent Order ID mismatch

### DIFF
--- a/upload/catalog/model/extension/payment/sagepay_server.php
+++ b/upload/catalog/model/extension/payment/sagepay_server.php
@@ -70,6 +70,7 @@ class ModelExtensionPaymentSagePayServer extends Model {
 	}
 
 	public function addOrder($order_info) {
+		$this->db->query("DELETE FROM `" . DB_PREFIX . "sagepay_server_order` WHERE `order_id` = '" . (int)$order_info['order_id'] . "'"); 
 		$this->db->query("INSERT INTO `" . DB_PREFIX . "sagepay_server_order` SET `order_id` = '" . (int)$order_info['order_id'] . "', `customer_id` = '" . (int)$this->customer->getId() . "', `VPSTxId` = '" . $this->db->escape($order_info['VPSTxId']) . "',  `VendorTxCode` = '" . $this->db->escape($order_info['VendorTxCode']) . "', `SecurityKey` = '" . $this->db->escape($order_info['SecurityKey']) . "', `date_added` = now(), `date_modified` = now(), `currency_code` = '" . $this->db->escape($order_info['currency_code']) . "', `total` = '" . $this->currency->format($order_info['total'], $order_info['currency_code'], false, false) . "'");
 	}
 


### PR DESCRIPTION
When a customer proceeds to SagePay and then hits the back button in their browser, the same order ID is kept in session.
The current addOrder function allows another database entry with the same order ID, but a different SecurityKey and other details are generated at SagePay. Future calls within the callback function tries to retrieve by Order ID, which will cause an issue as multiple Order IDs are present. This can cause an issue where the signatures do not match, due to a certain detail like the SecurityKey being different.
By removing old orders using the additional database query within this PR, this ensures that the order is current and allows the transaction to complete without error (providing the customer's card details are correct!)